### PR TITLE
Pass true to enableAnnotationMapping()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "nette/di": "^3.0.1",
     "symfony/cache": "^5.0",
     "symfony/config": "^5.0",
-    "symfony/validator": "^5.0"
+    "symfony/validator": "^5.2"
   },
   "require-dev": {
     "doctrine/annotations": "^1.8",

--- a/src/DI/ValidatorExtension.php
+++ b/src/DI/ValidatorExtension.php
@@ -78,7 +78,7 @@ final class ValidatorExtension extends CompilerExtension
 	private function setupMapping(ServiceDefinition $validatorBuilder): void
 	{
 		if ($this->config->mapping->annotations) {
-			$validatorBuilder->addSetup('enableAnnotationMapping');
+			$validatorBuilder->addSetup('enableAnnotationMapping', [true]);
 		}
 
 		$validatorBuilder->addSetup('addXmlMappings', [$this->config->mapping->xml]);

--- a/src/DI/ValidatorExtension.php
+++ b/src/DI/ValidatorExtension.php
@@ -80,7 +80,7 @@ final class ValidatorExtension extends CompilerExtension
 		$validatorBuilder->addSetup('enableAnnotationMapping', [true]);
 
 		if ($this->config->mapping->annotations) {
-			if ($this->getContainerBuilder()->findByType(Reader::class)) {
+			if ((bool) $this->getContainerBuilder()->findByType(Reader::class)) {
 				$validatorBuilder->addSetup('setDoctrineAnnotationReader');
 			} else {
 				$validatorBuilder->addSetup('addDefaultDoctrineAnnotationReader');

--- a/src/DI/ValidatorExtension.php
+++ b/src/DI/ValidatorExtension.php
@@ -57,7 +57,6 @@ final class ValidatorExtension extends CompilerExtension
 			->addSetup('setConstraintValidatorFactory', [new Statement(ContainerConstraintValidatorFactory::class)])
 			->setAutowired(false);
 
-		$this->setupMapping($validatorBuilder);
 		$this->setupCache($validatorBuilder);
 		$this->setupLoaders($validatorBuilder);
 		$this->setupObjectInitializers($validatorBuilder);
@@ -73,6 +72,7 @@ final class ValidatorExtension extends CompilerExtension
 		$validatorBuilder = $this->getContainerBuilder()->getDefinition($this->prefix('validatorBuilder'));
 		assert($validatorBuilder instanceof ServiceDefinition);
 		$this->setupTranslator($validatorBuilder);
+		$this->setupMapping($validatorBuilder);
 	}
 
 	private function setupMapping(ServiceDefinition $validatorBuilder): void

--- a/src/DI/ValidatorExtension.php
+++ b/src/DI/ValidatorExtension.php
@@ -77,8 +77,10 @@ final class ValidatorExtension extends CompilerExtension
 
 	private function setupMapping(ServiceDefinition $validatorBuilder): void
 	{
+		$validatorBuilder->addSetup('enableAnnotationMapping', [true]);
+
 		if ($this->config->mapping->annotations) {
-			$validatorBuilder->addSetup('enableAnnotationMapping', [true]);
+			$validatorBuilder->addSetup('setDoctrineAnnotationReader');
 		}
 
 		$validatorBuilder->addSetup('addXmlMappings', [$this->config->mapping->xml]);

--- a/src/DI/ValidatorExtension.php
+++ b/src/DI/ValidatorExtension.php
@@ -80,7 +80,11 @@ final class ValidatorExtension extends CompilerExtension
 		$validatorBuilder->addSetup('enableAnnotationMapping', [true]);
 
 		if ($this->config->mapping->annotations) {
-			$validatorBuilder->addSetup('setDoctrineAnnotationReader');
+			if ($this->getContainerBuilder()->findByType(Reader::class)) {
+				$validatorBuilder->addSetup('setDoctrineAnnotationReader');
+			} else {
+				$validatorBuilder->addSetup('addDefaultDoctrineAnnotationReader');
+			}
 		}
 
 		$validatorBuilder->addSetup('addXmlMappings', [$this->config->mapping->xml]);


### PR DESCRIPTION
Since symfony/validator 5.2: Not passing true as first argument to "Symfony\Component\Validator\ValidatorBuilder::enableAnnotationMapping" is deprecated. Pass true and call "addDefaultDoctrineAnnotationReader()" if you want to enable annotation mapping with Doctrine Annotations.