### PR TITLE
Use php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.html --coverage-src ./src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `phpdbg` with `php` in the `coverage` target of `Makefile`
- keep both GitHub Actions and local coverage commands aligned

## Motivation
- `contributte/contributte#73` tracks removing `phpdbg` from Contributte coverage targets

## Changes
- update the CI coverage command to use `-p php`
- update the local HTML coverage command to use `-p php`

## Testing
- [x] Verified `make -n coverage` prints the `php` command
- [ ] Full coverage run executed locally
- [ ] CI passes